### PR TITLE
Add seriallizing support for nsarray objects and Added deseriallizing from jsondata to NSArray

### DIFF
--- a/NSObject-ObjectMap/NSObject+ObjectMap.h
+++ b/NSObject-ObjectMap/NSObject+ObjectMap.h
@@ -40,6 +40,10 @@
 -(NSDictionary *)propertyDictionary;
 -(NSString *)nameOfClass;
 
+//jsondata -> Objects
++(id)objectOfClass:(NSString *)object fromJSONData:(NSData *)jsonData;
+
+
 // id -> Object
 +(id)objectOfClass:(NSString *)object fromJSON:(NSDictionary *)dict;
 +(NSArray *)arrayFromJSON:(NSArray *)jsonArray ofObjects:(NSString *)obj;

--- a/NSObject-ObjectMap/NSObject+ObjectMap.m
+++ b/NSObject-ObjectMap/NSObject+ObjectMap.m
@@ -441,14 +441,32 @@ static const char * getPropertyType(objc_property_t property) {
 }
 
 -(NSData *)JSONData{
-    NSDictionary *dict = [NSObject dictionaryWithPropertiesOfObject:self];
+    id dict = [NSObject jsonDataObjects:self];
     return [NSJSONSerialization dataWithJSONObject:dict options:NSJSONWritingPrettyPrinted error:nil];
 }
 
 -(NSString *)JSONString{
-    NSDictionary *dict = [NSObject dictionaryWithPropertiesOfObject:self];
+    id dict = [NSObject jsonDataObjects:self];
     NSData *JSONData = [NSJSONSerialization dataWithJSONObject:dict options:NSJSONWritingPrettyPrinted error:nil];
     return [[NSString alloc] initWithData:JSONData encoding:NSUTF8StringEncoding];
+}
+
++(id) jsonDataObjects:(id)obj{
+    id rtn = nil;
+    if([self isArray:obj]){
+        int length =[(NSArray*) obj count];
+        rtn = [NSMutableArray arrayWithCapacity:length];
+        for(int i=0;i<length;i++){
+            [rtn addObject:[NSObject dictionaryWithPropertiesOfObject:[(NSArray*) obj objectAtIndex:i]]];
+            
+        }
+        
+    }else{
+        rtn = [NSObject dictionaryWithPropertiesOfObject:obj];
+        
+    }
+    
+    return rtn;
 }
 
 +(NSDictionary *)dictionaryWithPropertiesOfObject:(id)obj

--- a/NSObject-ObjectMap/NSObject+ObjectMap.m
+++ b/NSObject-ObjectMap/NSObject+ObjectMap.m
@@ -205,7 +205,25 @@ static const short _base64DecodingTable[256] = {
     
     return nil;
 }
+#pragma mark - JSONData to Object
 
++(id)objectOfClass:(NSString *)object fromJSONData:(NSData *)jsonData {
+    NSError *error;
+    id rtn = nil;
+    id val = [NSJSONSerialization JSONObjectWithData:jsonData options:NSJSONReadingAllowFragments error:&error];
+    if([val isKindOfClass:[NSDictionary class]] ){
+        rtn = [NSObject objectOfClass:object fromJSON:val];
+    } else if([val isKindOfClass:[NSArray class]]){
+        int length = [((NSArray*) val) count];
+        NSMutableArray *resultArray = [NSMutableArray arrayWithCapacity:length];
+        for(int i=0 ;i<length; i++){
+            [resultArray addObject:[NSObject objectOfClass:object fromJSON:[(NSArray*)val objectAtIndex:i]]];
+        }
+        rtn = [[NSArray alloc] initWithArray:resultArray];
+    }
+    
+    return rtn;
+}
 #pragma mark - Dictionary to Object
 +(id)objectOfClass:(NSString *)object fromJSON:(NSDictionary *)dict {
     id newObject = [[NSClassFromString(object) alloc] init];


### PR DESCRIPTION
Add seriallizing support for nsarray objects 

for example

Model *m1 = [[Model alloc] init];
// ... set properties for m1
Model *m2 = [[Model alloc] init];
// ... set properties for m2

NSArray \* models = [NSArray arrayWithObjects:m1,m2, nil];

NSData\* jsonData = [models JSONData];
NSLog([models JSONString]);
# 

Added deseriallizing from jsondata to NSArray

for example

 NSString\* path =  [[NSBundle mainBundle] pathForResource:@"model" ofType:@"json"];

```
NSData *jsonData =[NSData dataWithContentsOfFile:path];
id rtn= [NSObject objectOfClass:@"Model" fromJSONData:jsonData];
if([rtn isKindOfClass:[NSArray class]]){
    // json is a collection of models
}else if([rtn isKindOfClass:[Model class]]){
    // json is a single model
}
```
