### PR TITLE
Fix on deserilized from object with NSDictionary property

### DIFF
--- a/NSObject-ObjectMap/NSObject+ObjectMap.m
+++ b/NSObject-ObjectMap/NSObject+ObjectMap.m
@@ -233,6 +233,10 @@ static const short _base64DecodingTable[256] = {
 
 #pragma mark - Dictionary to Object
 +(id)objectOfClass:(NSString *)object fromJSON:(NSDictionary *)dict {
+    if([object isEqualToString:@"NSDictionary"]){
+        return dict;
+    }
+    
     id newObject = [[NSClassFromString(object) alloc] init];
     NSDictionary *mapDictionary = [newObject propertyDictionary];
     


### PR DESCRIPTION
Going from JSON to Object

When the target object has an NSDictonary property, the deserilizing will fail on that property. This pull request fix this.
