### PR TITLE
Removing reserved properties from properties list

### DIFF
--- a/NSObject-ObjectMap/NSObject+ObjectMap.m
+++ b/NSObject-ObjectMap/NSObject+ObjectMap.m
@@ -590,7 +590,7 @@ static const char _base64EncodingTable[64] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefgh
     for (NSInteger i = 0; i < propertiesArray.count; i++) {
         NSString *key = propertiesArray[i];
         
-        if (![obj valueForKey:key]) {
+        if (![obj valueForKey:key] || [self isSystemReservedProperty:obj key:key]) {
             continue;
         }
         
@@ -614,6 +614,7 @@ static const char _base64EncodingTable[64] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefgh
     return [NSDictionary dictionaryWithDictionary:dict];
 }
 
+
 +(NSMutableArray *)propertiesArrayFromObject:(id)obj {
     
     NSMutableArray *props = [NSMutableArray array];
@@ -634,13 +635,21 @@ static const char _base64EncodingTable[64] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefgh
     if (![superClassName isEqualToString:@"NSObject"]) {
         [props addObjectsFromArray:[NSObject propertiesArrayFromObject:[[NSClassFromString(superClassName) alloc] init]]];
     }
-    else if([props containsObject:@"superclass"]) {
-         // At this point we know superclass is NSObject, so remove superclass property if present. Needed because iOS 8+ automatically adds superclass property to classes that implement protocols. 
-        [props removeObject:@"superclass"];
-    }
     
     return props;
 }
+
+// Needed because iOS 8 automatically adds properties that can't be properly serialized
+-(BOOL)isSystemReservedProperty:(id)obj key:(NSString *)key
+{
+    // properties set by iOS
+    if ([key isEqualToString:@"description"] || [key isEqualToString:@"debugDescription"] || [key isEqualToString:@"hash"] || [key isEqualToString:@"superclass"]) {
+        return YES;
+    }
+    
+    return NO;
+}
+
 
 -(BOOL)isSystemObject:(id)obj key:(NSString *)key{
     if ([[obj valueForKey:key] isKindOfClass:[NSString class]] || [[obj valueForKey:key] isKindOfClass:[NSNumber class]] || [[obj valueForKey:key] isKindOfClass:[NSDictionary class]]) {

--- a/NSObject-ObjectMap/NSObject+ObjectMap.m
+++ b/NSObject-ObjectMap/NSObject+ObjectMap.m
@@ -634,6 +634,10 @@ static const char _base64EncodingTable[64] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefgh
     if (![superClassName isEqualToString:@"NSObject"]) {
         [props addObjectsFromArray:[NSObject propertiesArrayFromObject:[[NSClassFromString(superClassName) alloc] init]]];
     }
+    else if([props containsObject:@"superclass"]) {
+         // At this point we know superclass is NSObject, so remove superclass property if present. Needed because iOS 8+ automatically adds superclass property to classes that implement protocols. 
+        [props removeObject:@"superclass"];
+    }
     
     return props;
 }


### PR DESCRIPTION
Superclass property is automatically added to properties list when a class implements a protocol in iOS 8+.

This causes infinite loops when the superclass added is NSObject. If superclass is NSObject then that is the signal to stop, so if iOS has automatically added a superclass property with a value of 'NSObject' we want to remove to prevent from trying to go beyond it. 

More info on the change in iOS 8+

http://www.redwindsoftware.com/blog/post/2014/08/20/NSObject-has-some-new-properties-in-iOS-8.aspx
http://stackoverflow.com/questions/24873062/retrieving-property-list-of-a-class-in-ios
